### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM golang:1.16-alpine
+FROM golang:1.19-alpine
 
 WORKDIR /app
 
-COPY go.mod ./
-COPY go.sum ./
+COPY . ./
+
 RUN go mod download
 
-COPY lz77/*.go ./lz77/
-COPY *.go ./
+RUN go build -o /xbscli
 
-RUN go build -o /xbscli-docker
-
-ENTRYPOINT ["/xbscli-docker", "-f", "-i", "-p", "-s"]
+ENTRYPOINT ["/xbscli", "-f", "-i", "-p", "-s"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.16-alpine
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY lz77/*.go ./lz77/
+COPY *.go ./
+
+RUN go build -o /xbscli-docker
+
+ENTRYPOINT ["/xbscli-docker", "-f", "-i", "-p", "-s"]

--- a/README.md
+++ b/README.md
@@ -21,4 +21,28 @@ xbscli \
   -f pretty
 ```
 
+## Supported formats (-f)
 
+* json (default)
+* pretty - formatted text
+* html - produces a basic HTML file similar to browser export of bookmarks as html. Handy as an input to [static-marks](https://darekkay.com/static-marks/)
+
+## Docker
+
+An alternate way to run xbscli
+
+### Build
+
+```sh
+ docker build -t xbscli .
+```
+
+### Run
+
+```sh
+ docker run --rm xbscli \
+  -s "https://xbsapi.myserver.com/api/v1" \
+  -i $(pass show xbs/id) \
+  -p $(pass show xbs/password) \
+  -f pretty
+```


### PR DESCRIPTION
Allows users to build and run xbscli using docker instead of Go - 

git clone https://github.com/mrusme/xbscli.git
cd xbscli
docker build -t xbscli-docker .
docker run --rm xbscli-docker -i "xbs id" -p "xbs key" -s "xbs url" -f pretty > bookmarks.txt